### PR TITLE
Remove warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=DEPENDENCIES,
     license='Apache 2.0',
     keywords='google auth oauth client',
-    classifiers=(
+    classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
@@ -55,5 +55,5 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
-    ),
+    ],
 )


### PR DESCRIPTION
The warning is as follows:
Warning: 'classifiers' should be a list, got type 'tuple'

Reference:	https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification