### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with io.open("README.rst", "r") as fh:
 
 setup(
     name="google-auth-httplib2",
-    version=version,
+    version=setuptools.sic(version),
     author="Google Cloud Platform",
     author_email="googleapis-packages@google.com",
     description="Google Authentication Library: httplib2 transport",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,22 @@
 
 import io
 
-from setuptools import setup
+import setuptools
+
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
 
 version = "0.1.0"
 
@@ -25,9 +40,9 @@ with io.open("README.rst", "r") as fh:
     long_description = fh.read()
 
 
-setup(
+setuptools.setup(
     name="google-auth-httplib2",
-    version=setuptools.sic(version),
+    version=sic(version),
     author="Google Cloud Platform",
     author_email="googleapis-packages@google.com",
     description="Google Authentication Library: httplib2 transport",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from -patch to .patch which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.