### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,11 +1,13 @@
 {
-  "name": "google-auth-httplib2",
-  "name_pretty": "Google Auth httplib2",
-  "client_documentation": "",
-  "issue_tracker": "https://github.com/googleapis/google-auth-library-python-httplib2/issues",
-  "release_level": "alpha",
-  "language": "python",
-  "library_type": "AUTH",
-  "repo": "googleapis/google-auth-library-python-httplib2",
-  "distribution_name": "google-auth-httplib2"
+    "name": "google-auth-httplib2",
+    "name_pretty": "Google Auth httplib2",
+    "client_documentation": "",
+    "issue_tracker": "https://github.com/googleapis/google-auth-library-python-httplib2/issues",
+    "release_level": "alpha",
+    "language": "python",
+    "library_type": "AUTH",
+    "repo": "googleapis/google-auth-library-python-httplib2",
+    "distribution_name": "google-auth-httplib2",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
Both `default_version` and `codeowner_team` have empty strings for this repo. By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs. 

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114
