### PR TITLE
fix: update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 version = "0.1.0"
 
-DEPENDENCIES = ["google-auth", "httplib2 >= 0.15.0", "six"]
+DEPENDENCIES = ["google-auth", "httplib2 >= 0.19.0", "six"]
 
 
 with io.open("README.rst", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ from setuptools import setup
 
 version = "0.1.0"
 
+
 DEPENDENCIES = ["google-auth", "httplib2 >= 0.19.0", "six"]
 
 


### PR DESCRIPTION
google-auth-httplib2:0.1.0 | Reference: CVE-2021-21240 | CVSS Score: 7.5 | Category: CWE-400 | httplib2 is a comprehensive HTTP client library for Python. In httplib2 before version 0.19.0, a malicious server which responds with long series of "\xa0" characters in the "www-authenticate" header may cause Denial of Service (CPU burn while parsing header) of the httplib2 client accessing said server. This is fixed in version 0.19.0 which contains a new implementation of auth headers parsing using the pyparsing library.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-python-httplib2/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #113 🦕
