### PR TITLE
deps: remove third-party mock library

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,6 @@ BLACK_PATHS = ["google_auth_httplib2.py", "tests"]
 
 TEST_DEPENDENCIES = [
     "flask",
-    "mock",
     "pytest",
     "pytest-cov",
     "pytest-localserver",

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -14,9 +14,9 @@
 
 import http.client
 import io
+from unittest import mock
 
 import httplib2
-import mock
 
 import google_auth_httplib2
 from tests import compliance

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = lint,py27,py34,py35,py36,pypy,cover
 [testenv]
 deps =
   flask
-  mock
   pytest
   pytest-cov
   pytest-localserver


### PR DESCRIPTION
`unittest.mock` is present since Python 3.3+, we don't need to depend on the external library for compatibility.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-python-httplib2/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
