### PR TITLE
tests: update default runtime used for tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,11 +32,11 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google_auth_httplib2.py", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
 
+# TODO(https://github.com/googleapis/google-auth-library-python-httplib2/issues/192):
+# Remove or restore testing for Python 3.7/3.8
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
-    "3.7",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,7 +75,6 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
     "unit",
-    "system",
     "cover",
     "lint",
     "lint_setup_py",

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,0 +1,8 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List all library dependencies and extras in this file.
+# Pin the version to the lower bound.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo==1.14.0
+google-auth==1.32.0
+httplib2==0.19.0


### PR DESCRIPTION
This PR includes the following fixes to the test environment:

- Fix presubmits following the changes in https://github.com/googleapis/testing-infra-docker/pull/491 which removes outdated setuptools which don't include a patch for CVE-2025-47273/CVE-2025-47273
- Move from Python 3.8 to Python 3.10 as the default runtime for most tests
- Remove `unit-3.7` / `unit-3.8` from the default nox session/presubmits. See https://github.com/googleapis/google-auth-library-python-httplib2/issues/192 where we will follow up on this