### PR TITLE
chore: remove config for older py versions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,28 +11,28 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', "3.11", "3.12", "3.13"]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ '{{' }} matrix.python {{ '}}' }}
+        python-version: ${{ matrix.python }}
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
+        COVERAGE_FILE: .coverage-${{ matrix.python }}
       run: |
-        nox -s unit-${{ '{{' }} matrix.python {{ '}}' }}
+        nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
-        path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
+        name: coverage-artifact-${{ matrix.python }}
+        path: .coverage-${{ matrix.python }}
         include-hidden-files: true
 
   cover:
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "{{ default_python_version }}"
+        python-version: "3.8"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -58,4 +58,4 @@ jobs:
       run: |
         find .coverage-results -type f -name '*.zip' -exec unzip {} \;
         coverage combine .coverage-results/**/.coverage*
-        coverage report --show-missing --fail-under={{ cov_level if cov_level != None else 100 }}
+        coverage report --show-missing --fail-under=99

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: {{unit_test_python_versions}}
+        python: ['3.7', '3.8', '3.9', '3.10', "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,61 @@
+on:
+  pull_request:
+    branches:
+      - main
+name: unittest
+jobs:
+  unit:
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2303): use `ubuntu-latest` once this bug is fixed.
+    # Use ubuntu-22.04 until Python 3.7 is removed from the test matrix
+    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python: {{unit_test_python_versions}}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ '{{' }} matrix.python {{ '}}' }}
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run unit tests
+      env:
+        COVERAGE_FILE: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
+      run: |
+        nox -s unit-${{ '{{' }} matrix.python {{ '}}' }}
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
+        path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
+        include-hidden-files: true
+
+  cover:
+    runs-on: ubuntu-latest
+    needs:
+        - unit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "{{ default_python_version }}"
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+    - name: Download coverage results
+      uses: actions/download-artifact@v4
+      with:
+        path: .coverage-results/
+    - name: Report coverage results
+      run: |
+        find .coverage-results -type f -name '*.zip' -exec unzip {} \;
+        coverage combine .coverage-results/**/.coverage*
+        coverage report --show-missing --fail-under={{ cov_level if cov_level != None else 100 }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,6 +35,8 @@ LINT_PATHS = ["docs", "google_auth_httplib2.py", "tests", "noxfile.py", "setup.p
 DEFAULT_PYTHON_VERSION = "3.9"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
+    "3.7",
+    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,6 @@ LINT_PATHS = ["docs", "google_auth_httplib2.py", "tests", "noxfile.py", "setup.p
 DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
-    "3.7",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.9"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,7 +79,6 @@ nox.options.sessions = [
     "unit-3.11",
     "unit-3.12",
     "unit-3.13",
-    "unit-3.14",
     "system",
     "cover",
     "lint",

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google_auth_httplib2.py", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.9"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.9",

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,12 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit",
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
+    "unit-3.14",
     "system",
     "cover",
     "lint",


### PR DESCRIPTION
This PR removes running the Kokoro job for Python `3.7` and `3.8`.
