### PR TITLE
chore: librarian release pull request: 20251212T201007Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:d7caef319a25d618e20ba798b103434700bfd80015f525802d87621ca2528c90
 libraries:
   - id: google-auth-httplib2
-    version: 0.2.1
+    version: 0.3.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 [1]: https://pypi.org/project/google-auth-httplib2/#history
 
+## [0.3.0](https://github.com/googleapis/google-auth-library-python-httplib2/compare/v0.2.1...v0.3.0) (2025-12-12)
+
+
+### Features
+
+* Add support for Python 3.14 (#202) ([bdf128e7586fbd66a56f77080bfd96d4463198e6](https://github.com/googleapis/google-auth-library-python-httplib2/commit/bdf128e7586fbd66a56f77080bfd96d4463198e6))
+
 ## [0.2.1](https://github.com/googleapis/google-auth-library-python-httplib2/compare/v0.2.0...v0.2.1) (2025-10-30)
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import io
 
 from setuptools import setup
 
-version = "0.2.1"
+version = "0.3.0"
 
 DEPENDENCIES = [
     "google-auth >= 1.32.0,<3.0.0",


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:d7caef319a25d618e20ba798b103434700bfd80015f525802d87621ca2528c90
<details><summary>google-auth-httplib2: 0.3.0</summary>

## [0.3.0](https://github.com/googleapis/google-auth-library-python-httplib2/compare/v0.2.1...v0.3.0) (2025-12-12)

### Features

* Add support for Python 3.14 (#202) ([bdf128e7](https://github.com/googleapis/google-auth-library-python-httplib2/commit/bdf128e7))

</details>